### PR TITLE
Add Docker support with Dockerfile and docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Docker
+.dockerignore
+node_modules
+npm-debug.log
+.next
+.git
+.gitignore
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# Use Node.js LTS as base image
+FROM node:20-alpine AS base
+
+# Install dependencies only when needed
+FROM base AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+# Copy package files
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Rebuild the source code only when needed
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Next.js collects anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+# Uncomment the following line to disable telemetry during the build.
+ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN npm run build
+
+# Production image, copy all the files and run next
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV production
+ENV NEXT_TELEMETRY_DISABLED 1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+
+# Set the correct permission for prerender cache
+RUN mkdir .next
+RUN chown nextjs:nodejs .next
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT 3000
+ENV HOSTNAME "0.0.0.0"
+
+CMD ["node", "server.js"]

--- a/docker-compose.simple.yml
+++ b/docker-compose.simple.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  app:
+    image: slmingol/nyt-connections-clone:latest
+    container_name: nyt-connections-clone
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+    restart: unless-stopped
+    networks:
+      - connections-network
+
+networks:
+  connections-network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: nyt-connections-clone
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+    restart: unless-stopped
+    networks:
+      - connections-network
+
+networks:
+  connections-network:
+    driver: bridge

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  output: 'standalone',
+};
 
 export default nextConfig;


### PR DESCRIPTION
## Description
This PR adds Docker containerization support to the NYT Connections Clone project.

## Changes
- ✨ Add multi-stage Dockerfile optimized for Next.js production builds
- 🐳 Add docker-compose.yml for easy container orchestration
- 📝 Add .dockerignore to exclude unnecessary files from Docker builds
- ⚙️ Update next.config.mjs with `output: 'standalone'` for optimal Docker performance

## Benefits
- Easy deployment with Docker
- Consistent development and production environments
- Smaller image sizes with multi-stage builds
- Non-root user for better security
- Simple setup with `docker-compose up`

## Usage
```bash
# Build and run
docker-compose up --build

# Access the app at http://localhost:3000
```

## Testing
Tested locally with Docker and docker-compose on macOS.